### PR TITLE
Fix #13 No longer hides header in comments.

### DIFF
--- a/RedditCrap/manifest.json
+++ b/RedditCrap/manifest.json
@@ -15,6 +15,7 @@
                 "http://www.reddit.com/*",
                 "https://www.reddit.com/*"
             ],
+            "exclude_globs": ["http://reddit.com/r/*/comments/*"],
             "js": [
                 "app/js/redditcrap.js"
             ],


### PR DESCRIPTION
added "exclude_blobs" to remove any comments section from the URLs the extension matches.
